### PR TITLE
feat: add CSS stylesheet support via css option and <style> tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ yarn-error.log*
 
 # Examples
 examples/*.pdf
+# Test Output
+test_output/

--- a/src/core/PdfEngine.ts
+++ b/src/core/PdfEngine.ts
@@ -14,7 +14,7 @@ export class PdfEngine {
     const html = HandlebarsRenderer.render(options.html, options.data);
 
     // 2. Parse HTML
-    const renderTree = HtmlParser.parse(html);
+    const renderTree = HtmlParser.parse(html, options.css);
 
     // 3. Initialize PDF
     const doc = await PDFDocument.create();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,12 @@ export interface GeneratePdfOptions {
   data?: Record<string, any>;
 
   /**
+   * Optional CSS stylesheet string. Supports tag, .class, #id selectors.
+   * Applied during parsing before inline styles (CSS cascade).
+   */
+  css?: string;
+
+  /**
    * Page layout configuration.
    */
   layout?: {


### PR DESCRIPTION
# CSS Stylesheet Support via css Option and <style> Tags

## Description
Adds comprehensive CSS stylesheet support to pdf-light, allowing both external CSS via the `css` option and inline `<style>` tags in HTML. This eliminates the need for verbose inline styles and enables reusable CSS rules.

Fixes #9

## Changes
- **Add `css?: string` option** to `GeneratePdfOptions` for external stylesheet support
- **Parse `<style>` tags** from HTML during the parsing phase
- **Support multiple CSS selectors**: tag selectors, `.class` selectors, and `#id` selectors
- **Implement CSS cascade**: base defaults → CSS rules → inline styles (with proper precedence)
- **Helper methods** added:
  - `extractStyleTags()` - Extract style content from HTML
  - `parseCss()` - Parse CSS rules into selector-property mappings
  - `matchesSelector()` - Match elements against CSS selectors
  - `applyCssRules()` - Apply CSS rules to elements following cascade rules

## Key Features
-  Backward compatible - `css` option is optional
-  CSS cascade properly implemented with correct specificity
- Inline styles always take precedence
- Support for both `<style>` tags and `css` option simultaneously
- Comprehensive test coverage with 6 test cases

## Test Coverage
The implementation includes 6 test cases:
1. **`<style>` tags support** - CSS rules in HTML style elements
2. **`css` option** - External stylesheet via options
3. **CSS Cascade** - Inline styles override CSS rules
4. **Selectors** - ID (#id) and class (.class) selector support
5. **Complex styling** - Multiple headings, paragraphs, and styling combinations
6. **Merged stylesheets** - Both `<style>` tags and `css` option together

## Example Usage

### Using `<style>` tags:
```html
<style>
  h1 { font-size: 28px; color: #000080; font-weight: bold; }
  p { color: #333333; margin-bottom: 15px; }
  .highlight { background-color: #FFFF00; }
</style>
<h1>Invoice #12345</h1>
<p class="highlight">Please review the details below.</p>
```

### Using `css` option:
```javascript
const css = `
  h1 { font-size: 28px; color: #000080; font-weight: bold; }
  p { color: #333333; margin-bottom: 15px; }
  .highlight { background-color: #FFFF00; }
`;

await generatePDF({
  html: htmlContent,
  css: css,
  layout: { pageSize: [595.28, 841.89] }
});
```

### Cascade example:
```html
<style>
  h1 { color: blue; }
</style>
<h1 style="color: red;">This will be red</h1>
```

## Implementation Details
The CSS support is implemented in the HTML parser phase:
1. `<style>` tags are extracted before HTML parsing
2. CSS is parsed into a rule map
3. During rendering, CSS rules are applied based on selector matching
4. Inline styles take precedence over CSS rules
5. Base defaults are applied first, then CSS, then inline styles

## Breaking Changes
None - this is a fully backward compatible feature.

## Related Issues
- Fixes #9 - CSS stylesheet support

